### PR TITLE
feat: Adding clear cache function and bypass cache parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.0.0
+
+### Adicionado
+
+- Suporte ao parâmetro `bypassCache` na função `fetchCepData`, permitindo ignorar o cache e forçar uma nova requisição.
+- Nova função pública `clearCepCache` para permitir a limpeza manual do cache de CEPs durante o runtime.
+
+### Documentação
+
+- Explicações detalhadas sobre os parâmetros `timeout` e `bypassCache`adicionadas ao README.
+- Nova seção no README sobre o cache interno e como limpá-lo com `clearCacheCep`
+
 ## 0.1.2
 
 ### Corrigido

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ void getAddress() async {
 }
 ```
 
+
+### Parâmetros Disponíveis
+
+A função `fetchCepData` aceita os seguintes parâmetros opcionais:
+- `timeout`: `Duration` - Define o tempo máximo para cada requisição de API. o intervalo permitido é de 1 a 10 segundos. O valor padrão é `Duration(seconds: 3)`.
+- `bypassCache`: `bool` - Se `true`, ignora o cache interno e força uma nova consulta às APIs mesmo que o CEP já tenha sido resolvido anteriormente. Útil em cenários onde os dados podem ter sido atualizados. O valor padrão é `false`;
+
+Se necessário, o cache pode ser limpo manualmente utilizando a função `clearCepCache()`
+
 ## Modelo de CEP
 
 ```dart

--- a/lib/cep_fetcher.dart
+++ b/lib/cep_fetcher.dart
@@ -84,14 +84,14 @@ Future<Cep> fetchCepData(
   throw CepNotFoundException(cep);
 }
 
+/// Clears all cached CEP results from memory.
+///
+/// Useful when you want to force fresh lookups or reset state during app usage.
+void clearCepCache() => _cepCache.clear();
+
 /// Internal cache accessor for testing purposes only.
 ///
 /// Exposes the in-memory CEP cache so it can be inspected in unit tests.
 /// Do not use in production code.
 @visibleForTesting
 Map<String, Cep> get internalCache => _cepCache;
-
-/// Clears the in-memory CEP cache. Useful for tests or if you want to
-/// force a fresh lookup in long-running apps.
-@visibleForTesting
-void clearCepCache() => _cepCache.clear();

--- a/lib/cep_fetcher.dart
+++ b/lib/cep_fetcher.dart
@@ -21,6 +21,9 @@ final Map<String, Cep> _cepCache = {};
 /// [timeout] defines the maximum duration for each request. Allowed range:
 /// between `Duration(seconds: 1)` and `Duration(seconds: 10)`.
 ///
+/// If [bypassCache] is true, any cached result for that CEP will be ignored
+/// and a fresh network lookup will occur.
+///
 /// Throws a [TimeoutOutOfRangeException] if the timeout is not between 1 and 10 seconds.
 ///
 /// Throws an [InvalidCepFormatException] if the CEP is not exactly 8 digits after normalization.
@@ -40,6 +43,7 @@ final Map<String, Cep> _cepCache = {};
 Future<Cep> fetchCepData(
   String cep, {
   Duration timeout = const Duration(seconds: 3),
+  bool bypassCache = false,
 }) async {
   if (timeout < Duration(seconds: 1) || timeout > Duration(seconds: 10)) {
     throw TimeoutOutOfRangeException(timeout);
@@ -54,7 +58,8 @@ Future<Cep> fetchCepData(
     throw CepNotFoundException(cleanCep);
   }
 
-  if (_cepCache.containsKey(cleanCep)) {
+  // If not bypassing, return cached result when available
+  if (!bypassCache && _cepCache.containsKey(cleanCep)) {
     return _cepCache[cleanCep]!;
   }
 
@@ -85,3 +90,8 @@ Future<Cep> fetchCepData(
 /// Do not use in production code.
 @visibleForTesting
 Map<String, Cep> get internalCache => _cepCache;
+
+/// Clears the in-memory CEP cache. Useful for tests or if you want to
+/// force a fresh lookup in long-running apps.
+@visibleForTesting
+void clearCepCache() => _cepCache.clear();

--- a/lib/src/network.dart
+++ b/lib/src/network.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 /// Current version of the cep_fetcher library.
-const String libraryVersion = '0.1.2';
+const String libraryVersion = '1.0.0';
 
 /// Default headers used in all HTTP requests performed by this package.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cep_fetcher
 description: "Pacote Dart simples para obter dados de endereço no Brasil a partir de um CEP usando múltiplas APIs."
-version: 0.1.2
+version: 1.0.0
 repository: https://github.com/lucasmarques2907/cep_fetcher
 license: MIT
 


### PR DESCRIPTION
## `clearCepCache` function
- `clearCepCache`: Used to clear the cache from all the CEPs successfully searched during the app's runtime.

## `bypassCache` parameter
- `bypassCache`: Used to ignore the CEPs stored in the cache and always get fresh information. this is disabled by default.